### PR TITLE
Fix failing doctests

### DIFF
--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -57,8 +57,8 @@ jobs:
 
       - name: Set up Git
         run: |
-          git config --global user.name "pybamm user"
-          git config --global user.email "pybammuser@pybamm.org"
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Test template generation
         run: nox -s template-tests
@@ -99,8 +99,8 @@ jobs:
 
       - name: Set up Git
         run: |
-          git config --global user.name "pybamm user"
-          git config --global user.email "pybammuser@pybamm.org"
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Check if the documentation can be built
         run: nox -s docs
@@ -173,6 +173,11 @@ jobs:
         run: |
           uv pip install copier jinja2-time
           copier copy . . --trust --defaults
+
+      - name: Set up Git
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Check if the documentation can be built
         working-directory: ./pybamm-example-project

--- a/.github/workflows/test_on_push.yml
+++ b/.github/workflows/test_on_push.yml
@@ -97,6 +97,11 @@ jobs:
       - name: Install nox
         run: uv pip install nox[uv]
 
+      - name: Set up Git
+        run: |
+          git config --global user.name "pybamm user"
+          git config --global user.email "pybammuser@pybamm.org"
+
       - name: Check if the documentation can be built
         run: nox -s docs
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@
 <!-- SPHINX-START -->
 [![Powered by NumFOCUS](https://img.shields.io/badge/powered%20by-NumFOCUS-orange.svg?style=flat&colorA=E1523D&colorB=007D8A)](http://numfocus.org)
 [![Copier](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/copier-org/copier/master/img/badge/badge-grayscale-inverted-border-red.json)](https://github.com/copier-org/copier)
+[![pybamm-cookie](https://img.shields.io/badge/%F0%9F%8D%AA%20pybamm--cookie-cf4c4c?style=flat&link=https%3A%2F%2Fgithub.com%2Fpybamm-team%2Fpybamm-cookie)](https://github.com/pybamm-team/pybamm-cookie)
+[![PyPI](https://img.shields.io/badge/PyPI-white?style=flat&logo=pypi&link=https%3A%2F%2Fpypi.org%2Fproject%2Fpybamm-cookie%2F)](https://pypi.org/project/pybamm-cookie/)
 [![Test template and generated project](https://github.com/pybamm-team/pybamm-cookie/actions/workflows/test_on_push.yml/badge.svg)](https://github.com/pybamm-team/pybamm-cookie/actions/workflows/test_on_push.yml)
 
 This repository contains a `copier` template for battery modeling projects using PyBaMM, released under the [BSD-3-Clause license](https://github.com/pybamm-team/pybamm-cookie/blob/main/LICENSE). Currently under active development.


### PR DESCRIPTION
Release `v0.1.1` broke the doctests because there was no global `git config` in [CI](https://github.com/pybamm-team/pybamm-cookie/actions/runs/10598179537/job/29370232706). This fixes it.
Also I added two badges in the readme for PyPI and the project itself, if anyone wants to show support they could include the `pybamm-cookie` badge in their project readme.

Fixes #56 